### PR TITLE
Avoid wrong file names on component.generator

### DIFF
--- a/battlecry/generators/component/component.generator.js
+++ b/battlecry/generators/component/component.generator.js
@@ -15,7 +15,7 @@ export default class ComponentGenerator extends Generator {
       if (file.path.includes(".spec.js")) {
         file.saveAs(`tests/cypress/integration/components/`, this.args.name);
       } else {
-        file.saveAs(`src/components/${this.args.name}/`, this.args.name);
+        file.saveAs(`src/components/__NaMe__/`, this.args.name);
       }
     });
   }


### PR DESCRIPTION
Hi, I hope I'm not being too intrusive.

I saw your library is using Battlecry (through the insights section on GitHub) and I have a suggestion.

By replacing `this.args.name` with `__NaMe__` on `saveAs`, the user can type anything, such as `card`, `component_name` or `component-name` and it will get converted to PascalCase. 

Occasionally I look at OS projects using to see if I can find patterns and improve the library and the docs, please don't feel like I'm spying on you.

Congrats on cobblestone and best luck!